### PR TITLE
autovideoconvert: add imxvideoconvert_g2d

### DIFF
--- a/gst/autoconvert/gstautovideoconvert.c
+++ b/gst/autoconvert/gstautovideoconvert.c
@@ -87,6 +87,13 @@ gst_auto_video_convert_init (GstAutoVideoConvert * autovideoconvert)
     },
     {
       .first_elements = { "capsfilter caps=\"video/x-raw\"", NULL, },
+      .colorspace_converters = { "imxvideoconvert_g2d", NULL },
+      .last_elements = { NULL, },
+      .filters = { NULL },
+      .rank = GST_RANK_PRIMARY + 1,
+    },
+    {
+      .first_elements = { "capsfilter caps=\"video/x-raw\"", NULL, },
       .colorspace_converters = { "videoconvertscale", NULL },
       .last_elements = { NULL, },
       .filters = { NULL },


### PR DESCRIPTION
On i.MX8 platform, autovideoconvert defaults to CPU-based processing as imxvideoconvert_g2d is not included as a listed filter, resulting in poor video playback performance.

Add imxvideoconvert_g2d to improve performance by utilizing hardware acceleration.